### PR TITLE
SortingGroup Functionality Fix

### DIFF
--- a/Assets/Scripts/IsoSpriteSorting.cs
+++ b/Assets/Scripts/IsoSpriteSorting.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering;
+
 
 public class IsoSpriteSorting : MonoBehaviour
 {
@@ -55,6 +57,8 @@ public class IsoSpriteSorting : MonoBehaviour
     public Vector3 SorterPositionOffset = new Vector3();
     public Vector3 SorterPositionOffset2 = new Vector3();
     public Renderer[] renderersToSort;
+    public bool useSortingGroup;
+    public SortingGroup sortingGroup;
 
     private Transform t;
 
@@ -67,6 +71,7 @@ public class IsoSpriteSorting : MonoBehaviour
 
     private void RefreshBounds()
     {
+
         cachedBounds = new Bounds2D(renderersToSort[0].bounds);
     }
 
@@ -180,9 +185,17 @@ public class IsoSpriteSorting : MonoBehaviour
     private void Setup()
     {
         t = transform;  //This needs to be here AND in the Awake function
-        if (renderersToSort == null || renderersToSort.Length == 0)
+        if (useSortingGroup)
         {
-            renderersToSort = GetComponentsInChildren<Renderer>();
+            sortingGroup = GetComponent<SortingGroup>();
+        }
+        else
+        {
+            if (renderersToSort == null || renderersToSort.Length == 0)
+            {
+                //SortingGroup groupsToSort = GetComponent<SortingGroup>();
+                renderersToSort = GetComponentsInChildren<Renderer>();
+            }
         }
         IsoSpriteSortingManager.RegisterSprite(this);
     }

--- a/Assets/Scripts/IsoSpriteSortingManager.cs
+++ b/Assets/Scripts/IsoSpriteSortingManager.cs
@@ -27,7 +27,6 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
                 }
                 else
                 {
-
                     staticSpriteList.Add(newSprite);
                     newSprite.SetupStaticCache();
                     SetupStaticDependencies(newSprite);
@@ -177,7 +176,15 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
         int count = spriteList.Count;
         for (int i = 0; i < count; ++i)
         {
-            spriteList[i].RendererSortingOrder = orderCurrent;
+            //
+            if (spriteList[i].useSortingGroup)
+            {
+                spriteList[i].sortingGroup.sortingOrder = orderCurrent;
+            }
+            else
+            {
+                spriteList[i].RendererSortingOrder = orderCurrent;
+            }
             orderCurrent += 1;
         }
     }
@@ -187,7 +194,15 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
         int startOrder = -spriteList.Count - 1;
         for (int i = 0; i < spriteList.Count; ++i)
         {
-            spriteList[i].RendererSortingOrder = startOrder + i;
+            if (spriteList[i].useSortingGroup)
+            {
+                spriteList[i].sortingGroup.sortingOrder = startOrder + i;
+            }
+            else
+            {
+                spriteList[i].RendererSortingOrder = startOrder + i;
+            }
+
         }
     }
 
@@ -202,6 +217,10 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
             {
                 destinationList.Add(sprite);
                 sprite.forceSort = false;
+            }
+            else if(sprite.useSortingGroup)
+            {
+                destinationList.Add(sprite);
             }
             else
             {
@@ -219,7 +238,7 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
 
     private static void SortListSimple(List<IsoSpriteSorting> list)
     {
-        list.Sort((a, b) =>
+        list.Sort((System.Comparison<IsoSpriteSorting>)((a, b) =>
         {
             if (!a || !b)
             {
@@ -229,6 +248,6 @@ public class IsoSpriteSortingManager : Singleton<IsoSpriteSortingManager>
             {
                 return IsoSpriteSorting.CompareIsoSorters(a, b);
             }
-        });
+        }));
     }
 }


### PR DESCRIPTION
Added checkbox for using sorting group component.
To use, add a sortingGroup component to the same object containing the IsoSpriteSorting component.
Can likely be improved to support several hierarchies of sorting groups.