### PR TITLE
Fix bug sorting a game object with multiple renderers

### DIFF
--- a/Assets/Scripts/IsoSpriteSorting.cs
+++ b/Assets/Scripts/IsoSpriteSorting.cs
@@ -67,7 +67,11 @@ public class IsoSpriteSorting : MonoBehaviour
 
     private void RefreshBounds()
     {
-        cachedBounds = new Bounds2D(renderersToSort[0].bounds);
+        Bounds groupBounds = renderersToSort[0].bounds;
+        foreach (Renderer childRenderer in renderersToSort) {
+            groupBounds.Encapsulate(childRenderer.bounds);
+        }
+        cachedBounds = new Bounds2D(groupBounds);
     }
 
     private void RefreshPoint1()


### PR DESCRIPTION
This fixes the computed bounds of game objects with multiple renderers.

Previously, the first renderer in the list of child objects was used as the bounds for the whole game object, leading to sorting glitches.